### PR TITLE
Cert Tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ COPY . .
 
 # Build camino-node and plugins
 RUN ./scripts/build.sh
+# Build tools
+RUN ./scripts/build_tools.sh
 
 # ============= Cleanup Stage ================
 FROM debian:11-slim AS execution

--- a/scripts/build_camino.sh
+++ b/scripts/build_camino.sh
@@ -42,6 +42,9 @@ CAMINO_NODE_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 source "$CAMINO_NODE_PATH"/scripts/constants.sh
 
 LDFLAGS="-X github.com/chain4travel/camino-node/version.GitCommit=$git_commit"
+LDFLAGS="$LDFLAGS -X github.com/chain4travel/camino-node/version.GitVersion=$git_tag"
+LDFLAGS="$LDFLAGS -X github.com/chain4travel/camino-node/version.CaminoGoGitCommit=$caminogo_commit"
+LDFLAGS="$LDFLAGS -X github.com/chain4travel/camino-node/version.CaminoGoGitVersion=$caminogo_tag"
 LDFLAGS="$LDFLAGS -X github.com/ava-labs/coreth/plugin/evm.GitCommit=$caminoethvm_commit"
 LDFLAGS="$LDFLAGS -X github.com/ava-labs/coreth/plugin/evm.Version=$caminoethvm_tag"
 LDFLAGS="$LDFLAGS $static_ld_flags"

--- a/scripts/build_releases.sh
+++ b/scripts/build_releases.sh
@@ -80,6 +80,8 @@ rm -rf $DEST_PATH && mkdir -p $DEST_PATH
 
 # build executables into build dir
 GOOS=linux GOARCH=amd64 GOAMD64=v2 $CAMINO_NODE_PATH/scripts/build.sh
+# build tools into build dir
+GOOS=linux GOARCH=amd64 GOAMD64=v2 $CAMINO_NODE_PATH/scripts/build_tools.sh
 # copy the license file
 cp $CAMINO_NODE_PATH/LICENSE $CAMINO_NODE_PATH/build
 

--- a/scripts/build_tools.sh
+++ b/scripts/build_tools.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "Building tools..."
+
+# Camino-Node root folder
+CAMINO_NODE_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+
+# Load the constants
+source "$CAMINO_NODE_PATH"/scripts/constants.sh
+
+# Create tools directory
+tools_dir=$build_dir/tools/
+mkdir -p $tools_dir
+
+go build -ldflags="-s -w" -o "$tools_dir/cert" "$CAMINO_NODE_PATH/tools/cert/"*.go

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -25,32 +25,19 @@ plugin_dir="$build_dir/plugins"
 camino_node_dockerhub_repo=${DOCKER_REPO:-"c4tplatform"}"/camino-node"
 
 # Current branch
-current_branch=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match || true)
+current_branch=$(git symbolic-ref -q --short HEAD || git describe --tags || echo unknown)
 
-git_commit=${CAMINO_NODE_COMMIT:-$( git rev-list -1 HEAD )}
+git_commit=${CAMINO_NODE_COMMIT:-$(git rev-parse --short HEAD)}
+git_tag=${CAMINO_NODE_TAG:-$(git describe --tags --abbrev=0 || echo unknown)}
 
-# caminoethvm git tag and sha
-module=$(grep -m1 caminoethvm $CAMINO_NODE_PATH/go.mod)
-replace=$(echo $module | cut -d' ' -f4)
-if [ ${replace} ]
-then
-    module=$replace
-fi
-
-# trim leading
-module="${module#"${module%%[![:space:]]*}"}"
-t=(${module//\ / })
-echo ${#t[*]}
-if [ ${#t[*]} -gt 1 ]
-then
-    caminoethvm_tag=${t[1]}
-
-    c=$(git ls-remote https://$module);c=(${c//\ / })
-    caminoethvm_commit=${c[0]}
-else
-    caminoethvm_tag="v0.0.0"
-    caminoethvm_commit="undefined"
-fi
+# caminogo and caminoethvm git tag and sha
+oldDir=$(pwd) && cd $CAMINO_NODE_PATH/dependencies/caminoethvm
+caminoethvm_commit=${CAMINOETHVM_COMMIT:-$( git rev-parse --short HEAD )}
+caminoethvm_tag=$(git describe --tags --abbrev=0 || echo unknown)
+cd $CAMINO_NODE_PATH/dependencies/caminogo
+caminogo_commit=${CAMINOGO_COMMIT:-$( git rev-parse --short HEAD )}
+caminogo_tag=$(git describe --tags --abbrev=0 || echo unknown)
+cd $oldDir
 
 # Static compilation
 static_ld_flags=''

--- a/tools/cert/main.go
+++ b/tools/cert/main.go
@@ -1,0 +1,56 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/ava-labs/avalanchego/network/peer"
+	"github.com/ava-labs/avalanchego/staking"
+)
+
+var (
+	keyFile  = "staker%s.key"
+	certFile = "staker%s.crt"
+	destPath = "./"
+)
+
+func main() {
+	var count = 1
+	flag.StringVar(&destPath, "destPath", destPath, "Destination path")
+	flag.IntVar(&count, "count", 1, "Number of certificates")
+	flag.Parse()
+
+	var num = ""
+	for i := 1; i <= count; i++ {
+		if count > 1 {
+			num = fmt.Sprintf("%d", i)
+		}
+
+		keyPath := path.Join(destPath, fmt.Sprintf(keyFile, num))
+		certPath := path.Join(destPath, fmt.Sprintf(certFile, num))
+
+		err := staking.InitNodeStakingKeyPair(keyPath, certPath)
+		if err != nil {
+			fmt.Printf("couldn't create certificate files: %s\n", err)
+			os.Exit(1)
+		}
+
+		cert, err := staking.LoadTLSCertFromFiles(keyPath, certPath)
+		if err != nil {
+			fmt.Printf("couldn't read staking certificate: %s\n", err)
+			os.Exit(1)
+		}
+
+		id, err := peer.CertToID(cert.Leaf)
+		if err != nil {
+			fmt.Printf("cannot extract nodeID from certificate: %s\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("NodeID%s: %s\n", num, id.String())
+	}
+}

--- a/tools/cert/main.go
+++ b/tools/cert/main.go
@@ -20,12 +20,12 @@ var (
 )
 
 func main() {
-	var count = 1
+	count := 1
 	flag.StringVar(&destPath, "destPath", destPath, "Destination path")
 	flag.IntVar(&count, "count", 1, "Number of certificates")
 	flag.Parse()
 
-	var num = ""
+	num := ""
 	for i := 1; i <= count; i++ {
 		if count > 1 {
 			num = fmt.Sprintf("%d", i)

--- a/version/string.go
+++ b/version/string.go
@@ -13,20 +13,22 @@ var (
 	// String is displayed when CLI arg --version is used
 	String string
 
-	// GitCommit is set in the build script at compile time
-	GitCommit string
+	// Following vars are set in the build script at compile time
+	GitCommit          = "unknown"
+	GitVersion         = "unknown"
+	CaminoGoGitCommit  = "unknown"
+	CaminoGoGitVersion = "unknown"
 )
 
 func init() {
-	format := "core: %s [database: %s"
+	format := "camino-node: %s, commit: %s\ncaminogo: %s, commit: %s\n  compat: %s [database: %s]\n"
 	args := []interface{}{
+		GitVersion,
+		GitCommit,
+		CaminoGoGitVersion,
+		CaminoGoGitCommit,
 		sdkVersion.Current,
 		sdkVersion.CurrentDatabase,
 	}
-	if GitCommit != "" {
-		format += ", commit=%s"
-		args = append(args, GitCommit)
-	}
-	format += "]\n"
 	String = fmt.Sprintf(format, args...)
 }


### PR DESCRIPTION
## Cert Tool
Introduces a tool which creates staker keys and certificates.
The filenames are staker.key and staker.crt

Parameters:
- count: number of certificates to be generated, default 1.
For count > 1 filenames are staker[#].key and staker[#].crt
- destPath: destination directory, must exists

Usage:
- `./build/tools/cert ` creates `staker.key` and `staker.crt` in `./` and displays the nodeID
- `./build/tools/crt --destPath=/home --count=2` creates `staker1.key`, `staker2.key`, `staker1.crt` and `staker2.crt` in `/home`

Example:
```
$ ./build/tools/cert 
NodeID: NodeID-4is4daTJfNKQBig98P5A832RSfSDhnd5H

$ ls -l | grep staker
-r--r--r-- 1 user group     1773 Dez  4 13:54 staker.crt
-r--r--r-- 1 user group     3272 Dez  4 13:54 staker.key

$ ./build/tools/cert --help
Usage of .\build\tools\cert:
  -count int
        Number of certificates (default 1)
  -destPath string
        Destination path (default "./")
```
### Version display change
During build scripts cleanup now more information from build scripts to camino-node are provided to get a better overview about versioning.
```
$ ./build/camino-node --version
camino-node: v0.3.1-alpha1, commit: fda61ec
caminogo: v0.3.1-alpha1, commit: ac00a5ad9
  compat: v0.2.0 [database: v1.4.5]
```