### PR TITLE
[CI] Trigger adjustments for docker and matrix tests

### DIFF
--- a/.github/workflows/build-and-test-mac-windows.yml
+++ b/.github/workflows/build-and-test-mac-windows.yml
@@ -1,8 +1,11 @@
 name: Build + Test Mac-Windows
 
 on:
+  pull_request:
+    tags-ignore: ["*"]
+    branches: [chain4travel, dev]
   push:
-    tags: ["*"] # Push events to every tag
+    branches: [chain4travel, dev]
 
 jobs:
   run_build_tests:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,10 +10,7 @@ on:
 jobs:
   run_build_unit_tests:
     name: build_unit_test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ macos-11, ubuntu-18.04]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,9 +1,8 @@
 name: Build + Publish Docker Image
 
 on:
-  push:
-    branches-ignore: ["**"]
-    tags: ["v*"]
+  release:
+    types: [created]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## More adjustment of CI workflows
- Run all tests on push of c4t/dev branch (instead on tags)
- --race tests only for ubuntu-latest
- Build docker only on release instead of v* tags