### PR TITLE
edit submodule to use dev branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "dependencies/caminoethvm"]
 	path = dependencies/caminoethvm
 	url = https://github.com/chain4travel/caminoethvm.git
+	branch = dev


### PR DESCRIPTION
This is to checkout submodule caminoethvm from dev branch.

This shouldn't be merged to chain4travel branch. When everything is ready for merging to c4t branch, this should be reverted.