### PR TITLE
Missing Propagation leads to default/nil config in chain backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "dependencies/caminoethvm"]
 	path = dependencies/caminoethvm
 	url = https://github.com/chain4travel/caminoethvm.git
+	branch = dev

--- a/node/node.go
+++ b/node/node.go
@@ -778,6 +778,7 @@ func (n *Node) initVMs() error {
 				BanffTime:                       version.GetBanffTime(n.Config.NetworkID),
 				MinPercentConnectedStakeHealthy: n.Config.MinPercentConnectedStakeHealthy,
 				UseCurrentHeight:                n.Config.UseCurrentHeight,
+				CaminoConfig:                    n.Config.CaminoConfig,
 			},
 		}),
 		vmRegisterer.Register(context.TODO(), constants.AVMID, &avm.Factory{


### PR DESCRIPTION
While working on the Proposal, i noticed that the config set in the LocalParams is not loaded into the backend on the executor.
This PR fixes that.
