### PR TITLE
Allows Multisig definition duplication -> resulting different aliases

### DIFF
--- a/scripts/build_genesis_generator.sh
+++ b/scripts/build_genesis_generator.sh
@@ -9,5 +9,21 @@ echo "Building Genesis Generator..."
 CAMINO_NODE_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 source "$CAMINO_NODE_PATH"/scripts/constants.sh
 
-target="$build_dir/genesis-generator"
-go build -o "$target" "$CAMINO_NODE_PATH/tools/genesis/"*.go
+# Download dependencies
+if [ ! -f $CAMINO_NODE_PATH/dependencies/caminoethvm/.git ]; then
+    echo "Initializing git submodules..."
+    git --git-dir $CAMINO_NODE_PATH/.git submodule update --init --recursive
+fi
+
+# Load the constants
+source "$CAMINO_NODE_PATH"/scripts/constants.sh
+
+echo "Downloading dependencies..."
+(cd $CAMINO_NODE_PATH && go mod download)
+
+# Create tools directory
+tools_dir=$build_dir/tools/
+mkdir -p $tools_dir
+
+target="$tools_dir/genesis-generator"
+go build -ldflags="-s -w" -o "$target" "$CAMINO_NODE_PATH/tools/genesis/"*.go

--- a/tools/genesis/README.md
+++ b/tools/genesis/README.md
@@ -9,11 +9,11 @@ genesis_generator \
   PATH_TO_XLSX_FILE \
   PATH_TO_JSON_TEMPLATE \
   NETWORK_NAME \
-  OPTIONAL_OUTPUT_PATH
+  OUTPUT_PATH
 ```
 where 
 - `NETWORK_NAME` has to be one of: `kopernikus`, `columbus` or `camino`.
-- `OUTPUT_PATH` should be a path to the directory where the genesis file will be saved. If ommited, `../genesis/generated` will be used. 
+- `OUTPUT_PATH` should be a path to the directory where the genesis file will be saved.
 
 Tool produces a file `genesis_<NETWORK_NAME>.json` in the `OUTPUT_PATH` directory.
 <br/>**:warning: Tool was not tested with Windows paths.**

--- a/tools/genesis/generated/genesis_kopernikus.json
+++ b/tools/genesis/generated/genesis_kopernikus.json
@@ -116,7 +116,7 @@
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-kopernikus1q670ss0jzj5ys2cjqdmpyjvejn0w2uqwlke6nd",
+        "avaxAddr": "X-kopernikus1qytfcm2amett26svvjvmjvqptg0evtl0gju29k",
         "xAmount": 1000000000000,
         "addressStates": {
           "consortiumMember": true,
@@ -133,7 +133,7 @@
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-kopernikus1qytfcm2amett26svvjvmjvqptg0evtl0gju29k",
+        "avaxAddr": "X-kopernikus13hq70rrgaycz66qsn3ek6m4q3j8ve2syktxmd9",
         "xAmount": 1000000000000,
         "addressStates": {
           "consortiumMember": true,
@@ -165,7 +165,7 @@
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-kopernikus1568qsn55nxsuwzhwreuk4a309uesc628y60rry",
+        "avaxAddr": "X-kopernikus1nyuw6rys0qm0hhc6yrp3sy4gd5e6g6lsr3gpdn",
         "xAmount": 838046700000000000,
         "addressStates": {
           "consortiumMember": false,
@@ -310,7 +310,7 @@
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-kopernikus1q670ss0jzj5ys2cjqdmpyjvejn0w2uqwlke6nd",
+        "avaxAddr": "X-kopernikus1c5548fwqekln6vc7vak8t54e9e5q0v5hu4tyff",
         "xAmount": 1000000000000,
         "addressStates": {
           "consortiumMember": false,
@@ -486,7 +486,26 @@
         "threshold": 2
       },
       {
-        "alias": "X-kopernikus1q670ss0jzj5ys2cjqdmpyjvejn0w2uqwlke6nd",
+        "alias": "X-kopernikus13hq70rrgaycz66qsn3ek6m4q3j8ve2syktxmd9",
+        "addresses": [
+          "X-kopernikus1vxmf8899y6x7dsam0xnr0hp6syzwz333dkvn2r",
+          "X-kopernikus1w3szy4e5excad4j8xp2ua0ukqcfq2uh4qn4sgc",
+          "X-kopernikus10q3dc78tw70m89s8lgl9fgwe9tfu4a0sfr6yjs",
+          "X-kopernikus1kuaaqcggcl8ke6dhm8zmuhl2xc544q8vd3eew3"
+        ],
+        "threshold": 2
+      },
+      {
+        "alias": "X-kopernikus1nyuw6rys0qm0hhc6yrp3sy4gd5e6g6lsr3gpdn",
+        "addresses": [
+          "X-kopernikus1vxmf8899y6x7dsam0xnr0hp6syzwz333dkvn2r",
+          "X-kopernikus10q3dc78tw70m89s8lgl9fgwe9tfu4a0sfr6yjs",
+          "X-kopernikus1kuaaqcggcl8ke6dhm8zmuhl2xc544q8vd3eew3"
+        ],
+        "threshold": 2
+      },
+      {
+        "alias": "X-kopernikus1c5548fwqekln6vc7vak8t54e9e5q0v5hu4tyff",
         "addresses": [
           "X-kopernikus1vxmf8899y6x7dsam0xnr0hp6syzwz333dkvn2r",
           "X-kopernikus1w3szy4e5excad4j8xp2ua0ukqcfq2uh4qn4sgc",
@@ -494,15 +513,6 @@
           "X-kopernikus1kuaaqcggcl8ke6dhm8zmuhl2xc544q8vd3eew3"
         ],
         "threshold": 3
-      },
-      {
-        "alias": "X-kopernikus1568qsn55nxsuwzhwreuk4a309uesc628y60rry",
-        "addresses": [
-          "X-kopernikus1vxmf8899y6x7dsam0xnr0hp6syzwz333dkvn2r",
-          "X-kopernikus10q3dc78tw70m89s8lgl9fgwe9tfu4a0sfr6yjs",
-          "X-kopernikus1kuaaqcggcl8ke6dhm8zmuhl2xc544q8vd3eew3"
-        ],
-        "threshold": 2
       }
     ]
   },

--- a/tools/genesis/main.go
+++ b/tools/genesis/main.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"path"
 
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
@@ -17,26 +16,15 @@ import (
 )
 
 func main() {
-	if len(os.Args) < 3 {
-		usage := fmt.Sprintf("Usage: %s <workbook> <genesis_json> <network>", os.Args[0])
+	if len(os.Args) < 5 {
+		usage := fmt.Sprintf("Usage: %s <workbook> <genesis_json> <network> <output_dir>", os.Args[0])
 		log.Panic(usage)
 	}
 
 	spreadsheetFile := os.Args[1]
 	genesisFile := os.Args[2]
 	networkName := os.Args[3]
-
-	outputPath := ""
-	if len(os.Args) == 5 {
-		outputPath = os.Args[4]
-	} else {
-		outputPath, _ = os.Getwd()
-		for outputPath != "/" && path.Base(outputPath) != "camino-node" {
-			outputPath = path.Dir(outputPath)
-		}
-
-		outputPath = path.Join(outputPath, "tools/genesis/generated")
-	}
+	outputPath := os.Args[4]
 
 	networkID := uint32(0)
 	switch networkName {


### PR DESCRIPTION
For the genesis we want to have different multisig aliases for the different control groups even if these contains the same addresses + threshold.
This makes us to change the TxID which for genesis was ids.EmptyID which now is MSig definition index in array

