### PR TITLE
genesis-bytes

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -966,6 +966,7 @@ func (n *Node) initInfoAPI() error {
 			AddSubnetValidatorFee:         n.Config.AddSubnetValidatorFee,
 			AddSubnetDelegatorFee:         n.Config.AddSubnetDelegatorFee,
 			VMManager:                     n.Config.VMManager,
+			GenesisBytes:                  n.Config.GenesisBytes,
 		},
 		n.Log,
 		n.chainManager,


### PR DESCRIPTION
This PR adds genesis bytes to info api params in order to support GetGenesisBytes request.