### PR TITLE
Admin API DNS Rebinding mitigation

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -941,6 +941,11 @@ func (n *Node) initAdminAPI() error {
 		n.Log.Info("skipping admin API initialization because it has been disabled")
 		return nil
 	}
+
+	if (n.Config.HTTPHost == "localhost" || n.Config.HTTPHost == "127.0.0.1") && !n.Config.APIConfig.AllowInsecureLocalhost {
+		return errors.New("localhost/127.0.0.1 are considered to be insecure hosts - please explicitly allow this by also setting --http-insecure-localhost")
+	}
+
 	n.Log.Info("initializing admin API")
 	service, err := admin.NewService(
 		admin.Config{


### PR DESCRIPTION
Depends on https://github.com/chain4travel/caminogo/pull/263
This PR adds a check so that the admin API has to be enabled with the awareness that its running on localhost. A new flag has to be set in order for it to be started, otherwise the node crashes with an error.

This is in order to sidestep the DNS Rebinding issue.
